### PR TITLE
Bugfix: Correctly escape regex values when big image

### DIFF
--- a/Form/DataTransformer/Base64ToImageTransformer.php
+++ b/Form/DataTransformer/Base64ToImageTransformer.php
@@ -34,10 +34,9 @@ class Base64ToImageTransformer implements DataTransformerInterface
         if (!isset($value['base64']) || !$value['base64']) {
             return null;
         }
-
-
-        $base64 = preg_replace('/data:.*;base64,/', '', $value['base64']);
-
+        
+        $base64 = preg_replace('/data\:.*?base64\,/', '', $value['base64']);
+        
         $filePath = tempnam(sys_get_temp_dir(), 'UploadedFile');
         $file = fopen($filePath, 'w');
         stream_filter_append($file, 'convert.base64-decode');


### PR DESCRIPTION
I had a few issues with large images and this regex piece of code. 
This pull request fixes this.